### PR TITLE
remove error message when just pressing enter

### DIFF
--- a/Client.js
+++ b/Client.js
@@ -55,6 +55,9 @@ Client.prototype.query = function(query, options, f) {
     setCurrentDatabase(this, USE_DATABASE_CMD[1]);
     return f(null);
   }
+  
+  // user just pressed enter
+  if(query == ''){ return f(null, ''); };
 
   if (query.toLowerCase().indexOf('quit') !== -1 || query.toLowerCase().indexOf('exit') !== -1) {
     this.emit('quit');

--- a/influxdb-cli
+++ b/influxdb-cli
@@ -69,7 +69,9 @@ Cli(function prompt(database_name) {
     if (res === undefined || res === null) {
       return console.log(prompt, '(empty result)');
     }
-
+    
+    // don't display a new line if user just pressed enter
+    if(res === ''){ return; }
 
     if (!Array.isArray(res)) {
       return console.log(prompt, res);


### PR DESCRIPTION
I don't know if this is the absolute best way to handle this behavior, but I often press enter a few times while I'm in a REPL just to put some space between things. The error messages were bugging me a little so I threw this together to remove them when the user presses enter with an empty query in the REPL.
