### PR TITLE
Show series names

### DIFF
--- a/influxdb-cli
+++ b/influxdb-cli
@@ -99,6 +99,9 @@ Cli(function prompt(database_name) {
 
       asciitable.push.apply(asciitable, table.points);
 
+      if (res.length > 1) {
+        console.log(table.name);
+      }
       console.log(asciitable.toString());
 
       if(truncated !== -1){


### PR DESCRIPTION
Resolves issues #8 and #9

Example output:

```
nameA
┌──────────────────┬─────────────────┬───────┐
│       time       │ sequence_number │ value │
├──────────────────┼─────────────────┼───────┤
│ 20/6/14 19:00:06 │ 9252350001      │ 31616 │
└──────────────────┴─────────────────┴───────┘
Query took  223 ms
nameB
┌──────────────────┬─────────────────┬─────────┐
│       time       │ sequence_number │ value   │
├──────────────────┼─────────────────┼─────────┤
│ 20/6/14 19:00:06 │ 9252050001      │ 1239248 │
└──────────────────┴─────────────────┴─────────┘
Query took  223 ms
```
